### PR TITLE
Use Red Hat family instead of specific versions of CentOS

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -5,7 +5,7 @@ copyright: Chef Software, Inc.
 copyright_email: joshua@chef.io
 license: Apache 2.0
 summary: An InSpec Compliance Profile
-version: 0.1.0
+version: 0.1.1
 
 # Initial testing and development of this profile is based on the
 # chef-server cookbook and its supported platforms.
@@ -16,23 +16,8 @@ supports:
     release: 14.04
   - os-name: ubuntu
     release: 12.04
-  - os-name: centos
-    release: 7.3.1611
-  - os-name: centos
-    release: 6.8
+  - platform-family: redhat
   # not yet for the PoC, but let's fill this in for now so we don't have to type it all later.
-  # - os-name: redhat
-  #   release: 7
-  # - os-name: redhat
-  #   release: 6
-  # - os-name: redhat
-  #   release: 5
-  # - os-name: centos
-  #   release: 5.0
-  # - os-name: oracle
-  #   release: 6
-  # - os-name: oracle
-  #   release: 5
   # - os-name: suse
   #   release: 11.4
   # - os-name: suse


### PR DESCRIPTION
CentOS versions were very specific.

Signed-off-by: Matt Ray <matthewhray@gmail.com>